### PR TITLE
Fix missing files in depends

### DIFF
--- a/depends/Makefile
+++ b/depends/Makefile
@@ -1,0 +1,181 @@
+.NOTPARALLEL :
+
+SOURCES_PATH ?= $(BASEDIR)/sources
+BASE_CACHE ?= $(BASEDIR)/built
+SDK_PATH ?= $(BASEDIR)/SDKs
+NO_QT ?=
+NO_WALLET ?=
+NO_UPNP ?=
+FALLBACK_DOWNLOAD_PATH ?= https://bitcoincore.org/depends-sources
+
+BUILD = $(shell ./config.guess)
+HOST ?= $(BUILD)
+PATCHES_PATH = $(BASEDIR)/patches
+BASEDIR = $(CURDIR)
+HASH_LENGTH:=11
+DOWNLOAD_CONNECT_TIMEOUT:=10
+DOWNLOAD_RETRIES:=3
+HOST_ID_SALT ?= salt
+BUILD_ID_SALT ?= salt
+
+host:=$(BUILD)
+ifneq ($(HOST),)
+host:=$(HOST)
+endif
+
+ifneq ($(DEBUG),)
+release_type=debug
+else
+release_type=release
+endif
+
+base_build_dir=$(BASEDIR)/work/build
+base_staging_dir=$(BASEDIR)/work/staging
+base_download_dir=$(BASEDIR)/work/download
+canonical_host:=$(shell ./config.sub $(HOST))
+build:=$(shell ./config.sub $(BUILD))
+
+build_arch =$(firstword $(subst -, ,$(build)))
+build_vendor=$(word 2,$(subst -, ,$(build)))
+full_build_os:=$(subst $(build_arch)-$(build_vendor)-,,$(build))
+build_os:=$(findstring linux,$(full_build_os))
+build_os+=$(findstring darwin,$(full_build_os))
+build_os:=$(strip $(build_os))
+ifeq ($(build_os),)
+build_os=$(full_build_os)
+endif
+
+host_arch=$(firstword $(subst -, ,$(canonical_host)))
+host_vendor=$(word 2,$(subst -, ,$(canonical_host)))
+full_host_os:=$(subst $(host_arch)-$(host_vendor)-,,$(canonical_host))
+host_os:=$(findstring linux,$(full_host_os))
+host_os+=$(findstring darwin,$(full_host_os))
+host_os+=$(findstring mingw32,$(full_host_os))
+host_os:=$(strip $(host_os))
+ifeq ($(host_os),)
+host_os=$(full_host_os)
+endif
+
+$(host_arch)_$(host_os)_prefix=$(BASEDIR)/$(host)
+$(host_arch)_$(host_os)_host=$(host)
+host_prefix=$($(host_arch)_$(host_os)_prefix)
+build_prefix=$(host_prefix)/native
+build_host=$(build)
+
+AT_$(V):=
+AT_:=@
+AT:=$(AT_$(V))
+
+all: install
+
+include hosts/$(host_os).mk
+include hosts/default.mk
+include builders/$(build_os).mk
+include builders/default.mk
+include packages/packages.mk
+
+build_id_string:=$(BUILD_ID_SALT)
+build_id_string+=$(shell $(build_CC) --version 2>/dev/null)
+build_id_string+=$(shell $(build_AR) --version 2>/dev/null)
+build_id_string+=$(shell $(build_CXX) --version 2>/dev/null)
+build_id_string+=$(shell $(build_RANLIB) --version 2>/dev/null)
+build_id_string+=$(shell $(build_STRIP) --version 2>/dev/null)
+
+$(host_arch)_$(host_os)_id_string:=$(HOST_ID_SALT)
+$(host_arch)_$(host_os)_id_string+=$(shell $(host_CC) --version 2>/dev/null)
+$(host_arch)_$(host_os)_id_string+=$(shell $(host_AR) --version 2>/dev/null)
+$(host_arch)_$(host_os)_id_string+=$(shell $(host_CXX) --version 2>/dev/null)
+$(host_arch)_$(host_os)_id_string+=$(shell $(host_RANLIB) --version 2>/dev/null)
+$(host_arch)_$(host_os)_id_string+=$(shell $(host_STRIP) --version 2>/dev/null)
+
+qt_packages_$(NO_QT) = $(qt_packages) $(qt_$(host_os)_packages) $(qt_$(host_arch)_$(host_os)_packages)
+wallet_packages_$(NO_WALLET) = $(wallet_packages)
+upnp_packages_$(NO_UPNP) = $(upnp_packages)
+
+packages += $($(host_arch)_$(host_os)_packages) $($(host_os)_packages) $(qt_packages_) $(wallet_packages_) $(upnp_packages_)
+native_packages += $($(host_arch)_$(host_os)_native_packages) $($(host_os)_native_packages)
+
+ifneq ($(qt_packages_),)
+native_packages += $(qt_native_packages)
+endif
+
+all_packages = $(packages) $(native_packages)
+
+meta_depends = Makefile funcs.mk builders/default.mk hosts/default.mk hosts/$(host_os).mk builders/$(build_os).mk
+
+$(host_arch)_$(host_os)_native_toolchain?=$($(host_os)_native_toolchain)
+
+include funcs.mk
+
+toolchain_path=$($($(host_arch)_$(host_os)_native_toolchain)_prefixbin)
+final_build_id_long+=$(shell $(build_SHA256SUM) config.site.in)
+final_build_id+=$(shell echo -n "$(final_build_id_long)" | $(build_SHA256SUM) | cut -c-$(HASH_LENGTH))
+$(host_prefix)/.stamp_$(final_build_id): $(native_packages) $(packages)
+	$(AT)rm -rf $(@D)
+	$(AT)mkdir -p $(@D)
+	$(AT)echo copying packages: $^
+	$(AT)echo to: $(@D)
+	$(AT)cd $(@D); $(foreach package,$^, tar xf $($(package)_cached); )
+	$(AT)touch $@
+
+$(host_prefix)/share/config.site : config.site.in $(host_prefix)/.stamp_$(final_build_id)
+	$(AT)@mkdir -p $(@D)
+	$(AT)sed -e 's|@HOST@|$(host)|' \
+            -e 's|@CC@|$(toolchain_path)$(host_CC)|' \
+            -e 's|@CXX@|$(toolchain_path)$(host_CXX)|' \
+            -e 's|@AR@|$(toolchain_path)$(host_AR)|' \
+            -e 's|@RANLIB@|$(toolchain_path)$(host_RANLIB)|' \
+            -e 's|@NM@|$(toolchain_path)$(host_NM)|' \
+            -e 's|@STRIP@|$(toolchain_path)$(host_STRIP)|' \
+            -e 's|@build_os@|$(build_os)|' \
+            -e 's|@host_os@|$(host_os)|' \
+            -e 's|@CFLAGS@|$(strip $(host_CFLAGS) $(host_$(release_type)_CFLAGS))|' \
+            -e 's|@CXXFLAGS@|$(strip $(host_CXXFLAGS) $(host_$(release_type)_CXXFLAGS))|' \
+            -e 's|@CPPFLAGS@|$(strip $(host_CPPFLAGS) $(host_$(release_type)_CPPFLAGS))|' \
+            -e 's|@LDFLAGS@|$(strip $(host_LDFLAGS) $(host_$(release_type)_LDFLAGS))|' \
+            -e 's|@allow_host_packages@|$(ALLOW_HOST_PACKAGES)|' \
+            -e 's|@no_qt@|$(NO_QT)|' \
+            -e 's|@no_wallet@|$(NO_WALLET)|' \
+            -e 's|@no_upnp@|$(NO_UPNP)|' \
+            -e 's|@debug@|$(DEBUG)|' \
+            $< > $@
+	$(AT)touch $@
+
+
+define check_or_remove_cached
+  mkdir -p $(BASE_CACHE)/$(host)/$(package) && cd $(BASE_CACHE)/$(host)/$(package); \
+  $(build_SHA256SUM) -c $($(package)_cached_checksum) >/dev/null 2>/dev/null || \
+  ( rm -f $($(package)_cached_checksum); \
+    if test -f "$($(package)_cached)"; then echo "Checksum mismatch for $(package). Forcing rebuild.."; rm -f $($(package)_cached_checksum) $($(package)_cached); fi )
+endef
+
+define check_or_remove_sources
+  mkdir -p $($(package)_source_dir); cd $($(package)_source_dir); \
+  test -f $($(package)_fetched) && ( $(build_SHA256SUM) -c $($(package)_fetched) >/dev/null 2>/dev/null || \
+    ( echo "Checksum missing or mismatched for $(package) source. Forcing re-download."; \
+      rm -f $($(package)_all_sources) $($(1)_fetched))) || true
+endef
+
+check-packages:
+	@$(foreach package,$(all_packages),$(call check_or_remove_cached,$(package));)
+check-sources:
+	@$(foreach package,$(all_packages),$(call check_or_remove_sources,$(package));)
+
+$(host_prefix)/share/config.site: check-packages
+
+check-packages: check-sources
+
+install: check-packages $(host_prefix)/share/config.site
+
+
+download-one: check-sources $(all_sources)
+
+download-osx:
+	@$(MAKE) -s HOST=x86_64-apple-darwin11 download-one
+download-linux:
+	@$(MAKE) -s HOST=x86_64-unknown-linux-gnu download-one
+download-win:
+	@$(MAKE) -s HOST=x86_64-w64-mingw32 download-one
+download: download-osx download-linux download-win
+
+.PHONY: install cached download-one download-osx download-linux download-win download check-packages check-sources

--- a/depends/patches/native_cdrkit/cdrkit-deterministic.patch
+++ b/depends/patches/native_cdrkit/cdrkit-deterministic.patch
@@ -1,0 +1,86 @@
+--- cdrkit-1.1.11.old/genisoimage/tree.c	2008-10-21 19:57:47.000000000 -0400
++++ cdrkit-1.1.11/genisoimage/tree.c	2013-12-06 00:23:18.489622668 -0500
+@@ -1139,8 +1139,9 @@
+ scan_directory_tree(struct directory *this_dir, char *path, 
+ 						  struct directory_entry *de)
+ {
+-	DIR		*current_dir;
++        int             current_file;
+ 	char		whole_path[PATH_MAX];
++        struct dirent  **d_list;
+ 	struct dirent	*d_entry;
+ 	struct directory *parent;
+ 	int		dflag;
+@@ -1164,7 +1165,8 @@
+ 	this_dir->dir_flags |= DIR_WAS_SCANNED;
+ 
+ 	errno = 0;	/* Paranoia */
+-	current_dir = opendir(path);
++	//current_dir = opendir(path);
++        current_file = scandir(path, &d_list, NULL, alphasort);
+ 	d_entry = NULL;
+ 
+ 	/*
+@@ -1173,12 +1175,12 @@
+ 	 */
+ 	old_path = path;
+ 
+-	if (current_dir) {
++	if (current_file >= 0) {
+ 		errno = 0;
+-		d_entry = readdir(current_dir);
++		d_entry = d_list[0];
+ 	}
+ 
+-	if (!current_dir || !d_entry) {
++	if (current_file < 0 || !d_entry) {
+ 		int	ret = 1;
+ 
+ #ifdef	USE_LIBSCHILY
+@@ -1191,8 +1193,8 @@
+ 			de->isorec.flags[0] &= ~ISO_DIRECTORY;
+ 			ret = 0;
+ 		}
+-		if (current_dir)
+-			closedir(current_dir);
++		if(d_list)
++			free(d_list);
+ 		return (ret);
+ 	}
+ #ifdef	ABORT_DEEP_ISO_ONLY
+@@ -1208,7 +1210,7 @@
+ 			errmsgno(EX_BAD, "use Rock Ridge extensions via -R or -r,\n");
+ 			errmsgno(EX_BAD, "or allow deep ISO9660 directory nesting via -D.\n");
+ 		}
+-		closedir(current_dir);
++		free(d_list);
+ 		return (1);
+ 	}
+ #endif
+@@ -1250,13 +1252,13 @@
+ 		 * The first time through, skip this, since we already asked
+ 		 * for the first entry when we opened the directory.
+ 		 */
+-		if (dflag)
+-			d_entry = readdir(current_dir);
++		if (dflag && current_file >= 0)
++			d_entry = d_list[current_file];
+ 		dflag++;
+ 
+-		if (!d_entry)
++		if (current_file < 0)
+ 			break;
+-
++                current_file--;
+ 		/* OK, got a valid entry */
+ 
+ 		/* If we do not want all files, then pitch the backups. */
+@@ -1348,7 +1350,7 @@
+ 		insert_file_entry(this_dir, whole_path, d_entry->d_name);
+ #endif	/* APPLE_HYB */
+ 	}
+-	closedir(current_dir);
++	free(d_list);
+ 
+ #ifdef APPLE_HYB
+ 	/*

--- a/depends/patches/qt/fix-cocoahelpers-macos.patch
+++ b/depends/patches/qt/fix-cocoahelpers-macos.patch
@@ -1,0 +1,70 @@
+From 0707260a4f8e64dfadf1df5f935e74cabb7c7d27 Mon Sep 17 00:00:00 2001
+From: Jake Petroules <jake.petroules@qt.io>
+Date: Sun, 1 Oct 2017 21:48:17 -0700
+Subject: [PATCH] Fix build error with macOS 10.13 SDK
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf8
+Content-Transfer-Encoding: 8bit
+
+Several of these variables/macros are no longer defined. We didn't
+validate the preconditions on iOS, tvOS, or watchOS, so no
+need to bother validating them on macOS either. Nor did we check the
+OSStatus result on any platform anyways.
+
+Task-number: QTBUG-63401
+Change-Id: Ife64dff767cf6d3f4b839fc53ec486181c176bf3
+(cherry-picked from 861544583511d4e6f7745d2339b26ff1cd44132b)
+Reviewed-by: Timur Pocheptsov <timur.pocheptsov@qt.io>
+Reviewed-by: Tor Arne VestbÃ¸ <tor.arne.vestbo@qt.io>
+---
+ src/plugins/platforms/cocoa/qcocoahelpers.h  |  2 +-
+ src/plugins/platforms/cocoa/qcocoahelpers.mm | 13 +------------
+ 2 files changed, 2 insertions(+), 13 deletions(-)
+
+diff --git old/qtbase/src/plugins/platforms/cocoa/qcocoahelpers.h new/qtbase/src/plugins/platforms/cocoa/qcocoahelpers.h
+index bbb3793..74371d5 100644
+--- old/qtbase/src/plugins/platforms/cocoa/qcocoahelpers.h
++++ new/qtbase/src/plugins/platforms/cocoa/qcocoahelpers.h
+@@ -80,7 +80,7 @@ QColor qt_mac_toQColor(CGColorRef color);
+ // Creates a mutable shape, it's the caller's responsibility to release.
+ HIMutableShapeRef qt_mac_QRegionToHIMutableShape(const QRegion &region);
+ 
+-OSStatus qt_mac_drawCGImage(CGContextRef inContext, const CGRect *inBounds, CGImageRef inImage);
++void qt_mac_drawCGImage(CGContextRef inContext, const CGRect *inBounds, CGImageRef inImage);
+ 
+ NSDragOperation qt_mac_mapDropAction(Qt::DropAction action);
+ NSDragOperation qt_mac_mapDropActions(Qt::DropActions actions);
+diff --git old/qtbase/src/plugins/platforms/cocoa/qcocoahelpers.mm new/qtbase/src/plugins/platforms/cocoa/qcocoahelpers.mm
+index cd73148..3f8429e 100644
+--- old/qtbase/src/plugins/platforms/cocoa/qcocoahelpers.mm
++++ new/qtbase/src/plugins/platforms/cocoa/qcocoahelpers.mm
+@@ -544,15 +544,8 @@ NSRect qt_mac_flipRect(const QRect &rect)
+     return NSMakeRect(rect.x(), flippedY, rect.width(), rect.height());
+ }
+ 
+-OSStatus qt_mac_drawCGImage(CGContextRef inContext, const CGRect *inBounds, CGImageRef inImage)
++void qt_mac_drawCGImage(CGContextRef inContext, const CGRect *inBounds, CGImageRef inImage)
+ {
+-    // Verbatim copy if HIViewDrawCGImage (as shown on Carbon-Dev)
+-    OSStatus err = noErr;
+-
+-    require_action(inContext != NULL, InvalidContext, err = paramErr);
+-    require_action(inBounds != NULL, InvalidBounds, err = paramErr);
+-    require_action(inImage != NULL, InvalidImage, err = paramErr);
+-
+     CGContextSaveGState( inContext );
+     CGContextTranslateCTM (inContext, 0, inBounds->origin.y + CGRectGetMaxY(*inBounds));
+     CGContextScaleCTM(inContext, 1, -1);
+@@ -560,10 +553,6 @@ OSStatus qt_mac_drawCGImage(CGContextRef inContext, const CGRect *inBounds, CGIm
+     CGContextDrawImage(inContext, *inBounds, inImage);
+ 
+     CGContextRestoreGState(inContext);
+-InvalidImage:
+-InvalidBounds:
+-InvalidContext:
+-        return err;
+ }
+ 
+ Qt::MouseButton cocoaButton2QtButton(NSInteger buttonNum)
+-- 
+2.7.4

--- a/depends/patches/qt/fix-xcb-include-order.patch
+++ b/depends/patches/qt/fix-xcb-include-order.patch
@@ -1,0 +1,49 @@
+--- old/qtbase/src/plugins/platforms/xcb/xcb_qpa_lib.pro 2015-03-17
++++ new/qtbase/src/plugins/platforms/xcb/xcb_qpa_lib.pro 2015-03-17
+@@ -76,8 +76,6 @@
+ 
+ DEFINES += $$QMAKE_DEFINES_XCB
+ LIBS += $$QMAKE_LIBS_XCB
+-QMAKE_CXXFLAGS += $$QMAKE_CFLAGS_XCB
+-QMAKE_CFLAGS += $$QMAKE_CFLAGS_XCB
+ 
+ CONFIG += qpa/genericunixfontdatabase
+ 
+@@ -89,7 +87,8 @@
+ contains(QT_CONFIG, xcb-qt) {
+     DEFINES += XCB_USE_RENDER
+     XCB_DIR = ../../../3rdparty/xcb
+-    INCLUDEPATH += $$XCB_DIR/include $$XCB_DIR/sysinclude
++    QMAKE_CFLAGS += -I$$XCB_DIR/include -I$$XCB_DIR/sysinclude $$QMAKE_CFLAGS_XCB
++    QMAKE_CXXFLAGS += -I$$XCB_DIR/include -I$$XCB_DIR/sysinclude $$QMAKE_CFLAGS_XCB
+     LIBS += -lxcb -L$$MODULE_BASE_OUTDIR/lib -lxcb-static$$qtPlatformTargetSuffix()
+ } else {
+     LIBS += -lxcb -lxcb-image -lxcb-icccm -lxcb-sync -lxcb-xfixes -lxcb-shm -lxcb-randr -lxcb-shape -lxcb-keysyms -lxcb-xinerama
+--- old/qtbase/src/plugins/platforms/xcb/xcb-static/xcb-static.pro
++++ new/qtbase/src/plugins/platforms/xcb/xcb-static/xcb-static.pro
+@@ -9,7 +9,8 @@
+ 
+ XCB_DIR = ../../../../3rdparty/xcb
+ 
+-INCLUDEPATH += $$XCB_DIR/include $$XCB_DIR/include/xcb $$XCB_DIR/sysinclude
++QMAKE_CFLAGS += -I$$XCB_DIR/include -I$$XCB_DIR/include/xcb -I$$XCB_DIR/sysinclude
++QMAKE_CXXFLAGS += -I$$XCB_DIR/include -I$$XCB_DIR/include/xcb -I$$XCB_DIR/sysinclude
+ 
+ QMAKE_CXXFLAGS += $$QMAKE_CFLAGS_XCB
+ QMAKE_CFLAGS += $$QMAKE_CFLAGS_XCB
+--- old/qtbase/src/plugins/platforms/xcb/xcb-plugin.pro
++++ new/qtbase/src/plugins/platforms/xcb/xcb-plugin.pro
+@@ -6,6 +6,13 @@
+     qxcbmain.cpp
+ OTHER_FILES += xcb.json README
+ 
++contains(QT_CONFIG, xcb-qt) {
++    DEFINES += XCB_USE_RENDER
++    XCB_DIR = ../../../3rdparty/xcb
++    QMAKE_CFLAGS += -I$$XCB_DIR/include -I$$XCB_DIR/sysinclude $$QMAKE_CFLAGS_XCB
++    QMAKE_CXXFLAGS += -I$$XCB_DIR/include -I$$XCB_DIR/sysinclude $$QMAKE_CFLAGS_XCB
++}
++
+ PLUGIN_TYPE = platforms
+ PLUGIN_CLASS_NAME = QXcbIntegrationPlugin
+ !equals(TARGET, $$QT_DEFAULT_QPA_PLUGIN): PLUGIN_EXTENDS = -

--- a/depends/patches/qt/fix_qt_pkgconfig.patch
+++ b/depends/patches/qt/fix_qt_pkgconfig.patch
@@ -1,0 +1,11 @@
+--- old/qtbase/mkspecs/features/qt_module.prf
++++ new/qtbase/mkspecs/features/qt_module.prf
+@@ -245,7 +245,7 @@
+ load(qt_targets)
+ 
+ # this builds on top of qt_common
+-!internal_module:!lib_bundle:if(unix|mingw) {
++unix|mingw {
+     CONFIG += create_pc
+     QMAKE_PKGCONFIG_DESTDIR = pkgconfig
+     host_build: \

--- a/depends/patches/qt/mingw-uuidof.patch
+++ b/depends/patches/qt/mingw-uuidof.patch
@@ -1,0 +1,44 @@
+--- old/qtbase/src/plugins/platforms/windows/qwindowscontext.cpp
++++ new/qtbase/src/plugins/platforms/windows/qwindowscontext.cpp
+@@ -77,7 +77,7 @@
+ #include <stdlib.h>
+ #include <stdio.h>
+ #include <windowsx.h>
+-#ifndef Q_OS_WINCE
++#if !defined(Q_OS_WINCE) && (!defined(USE___UUIDOF) || (defined(USE___UUIDOF) && USE___UUIDOF == 1))
+ #  include <comdef.h>
+ #endif
+ 
+@@ -814,7 +814,7 @@
+                           HWND_MESSAGE, NULL, static_cast<HINSTANCE>(GetModuleHandle(0)), NULL);
+ }
+ 
+-#ifndef Q_OS_WINCE
++#if !defined(Q_OS_WINCE) && (!defined(USE___UUIDOF) || (defined(USE___UUIDOF) && USE___UUIDOF == 1))
+ // Re-engineered from the inline function _com_error::ErrorMessage().
+ // We cannot use it directly since it uses swprintf_s(), which is not
+ // present in the MSVCRT.DLL found on Windows XP (QTBUG-35617).
+@@ -833,7 +833,7 @@
+          return QString::asprintf("IDispatch error #%u", uint(wCode));
+      return QString::asprintf("Unknown error 0x0%x", uint(comError.Error()));
+ }
+-#endif // !Q_OS_WINCE
++#endif // !defined(Q_OS_WINCE) && (!defined(USE___UUIDOF) || (defined(USE___UUIDOF) && USE___UUIDOF == 1))
+ 
+ /*!
+     \brief Common COM error strings.
+@@ -901,12 +901,12 @@
+     default:
+         break;
+     }
+-#ifndef Q_OS_WINCE
++#if !defined(Q_OS_WINCE) && (!defined(USE___UUIDOF) || (defined(USE___UUIDOF) && USE___UUIDOF == 1))
+     _com_error error(hr);
+     result += QByteArrayLiteral(" (");
+     result += errorMessageFromComError(error);
+     result += ')';
+-#endif // !Q_OS_WINCE
++#endif // !defined(Q_OS_WINCE) && (!defined(USE___UUIDOF) || (defined(USE___UUIDOF) && USE___UUIDOF == 1))
+     return result;
+ }
+ 

--- a/depends/patches/qt/pidlist_absolute.patch
+++ b/depends/patches/qt/pidlist_absolute.patch
@@ -1,0 +1,37 @@
+diff -dur old/qtbase/src/plugins/platforms/windows/qwindowscontext.h new/qtbase/src/plugins/platforms/windows/qwindowscontext.h
+--- old/qtbase/src/plugins/platforms/windows/qwindowscontext.h
++++ new/qtbase/src/plugins/platforms/windows/qwindowscontext.h
+@@ -136,10 +136,18 @@
+     inline void init();
+ 
+     typedef HRESULT (WINAPI *SHCreateItemFromParsingName)(PCWSTR, IBindCtx *, const GUID&, void **);
++#if defined(Q_CC_MINGW) && (!defined(__MINGW64_VERSION_MAJOR) || __MINGW64_VERSION_MAJOR < 3)
++    typedef HRESULT (WINAPI *SHGetKnownFolderIDList)(const GUID &, DWORD, HANDLE, ITEMIDLIST **);
++#else
+     typedef HRESULT (WINAPI *SHGetKnownFolderIDList)(const GUID &, DWORD, HANDLE, PIDLIST_ABSOLUTE *);
++#endif
+     typedef HRESULT (WINAPI *SHGetStockIconInfo)(int , int , _SHSTOCKICONINFO *);
+     typedef HRESULT (WINAPI *SHGetImageList)(int, REFIID , void **);
++#if defined(Q_CC_MINGW) && (!defined(__MINGW64_VERSION_MAJOR) || __MINGW64_VERSION_MAJOR < 3)
++    typedef HRESULT (WINAPI *SHCreateItemFromIDList)(const ITEMIDLIST *, REFIID, void **);
++#else
+     typedef HRESULT (WINAPI *SHCreateItemFromIDList)(PCIDLIST_ABSOLUTE, REFIID, void **);
++#endif
+ 
+     SHCreateItemFromParsingName sHCreateItemFromParsingName;
+     SHGetKnownFolderIDList sHGetKnownFolderIDList;
+diff -dur old/qtbase/src/plugins/platforms/windows/qwindowsdialoghelpers.cpp new/qtbase/src/plugins/platforms/windows/qwindowsdialoghelpers.cpp
+--- old/qtbase/src/plugins/platforms/windows/qwindowsdialoghelpers.cpp
++++ new/qtbase/src/plugins/platforms/windows/qwindowsdialoghelpers.cpp
+@@ -1016,7 +1016,11 @@
+             qWarning() << __FUNCTION__ << ": Invalid CLSID: " << url.path();
+             return Q_NULLPTR;
+         }
++#if defined(Q_CC_MINGW) && (!defined(__MINGW64_VERSION_MAJOR) || __MINGW64_VERSION_MAJOR < 3)
++        ITEMIDLIST *idList;
++#else
+         PIDLIST_ABSOLUTE idList;
++#endif
+         HRESULT hr = QWindowsContext::shell32dll.sHGetKnownFolderIDList(uuid, 0, 0, &idList);
+         if (FAILED(hr)) {
+             qErrnoWarning("%s: SHGetKnownFolderIDList(%s)) failed", __FUNCTION__, qPrintable(url.toString()));

--- a/depends/patches/zeromq/0001-fix-build-with-older-mingw64.patch
+++ b/depends/patches/zeromq/0001-fix-build-with-older-mingw64.patch
@@ -1,0 +1,30 @@
+From 1a159c128c69a42d90819375c06a39994f3fbfc1 Mon Sep 17 00:00:00 2001
+From: Cory Fields <cory-nospam-@coryfields.com>
+Date: Tue, 28 Nov 2017 20:33:25 -0500
+Subject: [PATCH] fix build with older mingw64
+
+---
+ src/windows.hpp | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/src/windows.hpp b/src/windows.hpp
+index 99e889d..e69038e 100644
+--- a/src/windows.hpp
++++ b/src/windows.hpp
+@@ -55,6 +55,13 @@
+ #include <winsock2.h>
+ #include <windows.h>
+ #include <mswsock.h>
++
++#if defined __MINGW64_VERSION_MAJOR && __MINGW64_VERSION_MAJOR < 4
++// Workaround for mingw-w64 < v4.0 which did not include ws2ipdef.h in iphlpapi.h.
++// Fixed in mingw-w64 by 9bd8fe9148924840d315b4c915dd099955ea89d1.
++#include <ws2def.h>
++#include <ws2ipdef.h>
++#endif
+ #include <iphlpapi.h>
+
+ #if !defined __MINGW32__
+--
+2.7.4
+

--- a/depends/patches/zeromq/0002-disable-pthread_set_name_np.patch
+++ b/depends/patches/zeromq/0002-disable-pthread_set_name_np.patch
@@ -1,0 +1,35 @@
+From 6e6b47d5ab381c3df3b30bb0b0a6cf210dfb1eba Mon Sep 17 00:00:00 2001
+From: Cory Fields <cory-nospam-@coryfields.com>
+Date: Mon, 5 Mar 2018 14:22:05 -0500
+Subject: [PATCH] disable pthread_set_name_np
+
+pthread_set_name_np adds a Glibc requirement on >= 2.12.
+---
+ src/thread.cpp | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/thread.cpp b/src/thread.cpp
+index 4fc59c3e..c3fdfd46 100644
+--- a/src/thread.cpp
++++ b/src/thread.cpp
+@@ -220,7 +220,7 @@ void zmq::thread_t::setThreadName(const char *name_)
+  */
+     if (!name_)
+         return;
+-
++#if 0
+ #if defined(ZMQ_HAVE_PTHREAD_SETNAME_1)
+     int rc = pthread_setname_np(name_);
+     if(rc) return;
+@@ -233,6 +233,8 @@ void zmq::thread_t::setThreadName(const char *name_)
+ #elif defined(ZMQ_HAVE_PTHREAD_SET_NAME)
+     pthread_set_name_np(descriptor, name_);
+ #endif
++#endif
++    return;
+ }
+ 
+ #endif
+-- 
+2.11.1
+


### PR DESCRIPTION
Puts the missing files back in the depends directory. The .gitignore in the base of the repo leaves these out by default. We may want to adjust that, for now if new Makefiles or .patch files need to be added they have to be done manually.

resolves #6 